### PR TITLE
APP-2639 Improve 276/277 handling

### DIFF
--- a/lib/hippo/parser/segment.rb
+++ b/lib/hippo/parser/segment.rb
@@ -9,6 +9,10 @@ module Hippo
 
         fields.each_with_index do |value, index|
           field = self.class.fields[index]
+          
+          # IAB: I don't know if this is really needed, but I ran into an error here at one point during my
+          # testing and added this check. I don't think it hurts to have it and may help in some cases.
+          next unless field.present?
 
           # if the field is an array that means it is a
           # composite field


### PR DESCRIPTION
This update to the hippo code allows the propagation of an error status for specific transaction sets to the application, rather than simply aborting the parsing process on an error. It will need to be merged before the application merge happens, but the latter will need to be deployed almost immediately thereafter or the transaction sets with errors may be treated as complete sets (with some information lost). An alternative would be to make the new app version use this branch until everything can be updated and then merge this and switch the app back to using the master branch.
